### PR TITLE
More flexible time string parsing

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,7 +13,7 @@ let fontSize = '20vw';
 
 if (params.time) {
 
-  seconds = safeArray.from(time.matchAll(/(\d+[hms])/g)).reduce((sum, [raw]) => {
+  seconds = safeArray.from(params.time.matchAll(/(\d+[hms])/g)).reduce((sum, [raw]) => {
     const [n, x] = [raw.slice(0, -1), raw.at(-1)];
     return sum + (n * (x == "h" ? 3600 : (x == "m" ? 60 : 1)))
   }, 0);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,13 +12,11 @@ let seconds = safeParseNumber(params.seconds);
 let fontSize = '20vw';
 
 if (params.time) {
-  const parts = params.time.match(/(\d+)h(\d+)m(\d+)s/);
-  if (parts) {
-    const [, hours, minutes, s] = parts;
-    params.hours = hours;
-    params.minutes = minutes;
-    seconds = safeParseNumber(s);
-  }
+
+  seconds = safeArray.from(time.matchAll(/(\d+[hms])/g)).reduce((sum, [raw]) => {
+    const [n, x] = [raw.slice(0, -1), raw.at(-1)];
+    return sum + (n * (x == "h" ? 3600 : (x == "m" ? 60 : 1)))
+  }, 0);
 }
 
 if (params.hours) {


### PR DESCRIPTION
The changes that I've added allow time strings to include as many "blocks" as desired—from hms to hs to ms to s. They can also be included in any order (e.g. smh)